### PR TITLE
Open class networkClientManger to can inherit outside module

### DIFF
--- a/Sources/SwiftNetworkWrap/ClientManager/NetworkClientManager.swift
+++ b/Sources/SwiftNetworkWrap/ClientManager/NetworkClientManager.swift
@@ -10,7 +10,7 @@ import Combine
 
 public typealias AnyPublisherResult<M> = AnyPublisher<M, APIError>
 
-public class NetworkClientManager<Target: RequestBuilder> {
+open class NetworkClientManager<Target: RequestBuilder> {
 
     // The URLSession client is use to call request with URLSession Data Task Publisher
     private let clientURLSession: NetworkClient


### PR DESCRIPTION
The error you are encountering, `Cannot inherit from non-open class 'NetworkClientManager<DefaultHTTPRequest>' outside of its defining module`, occurs because in Swift, a class must be marked as `open` to allow for subclassing outside of its defining module. By default, classes are `internal`, meaning they can only be subclassed within the same module. If a class is marked as `public`, it can be accessed from outside the module, but not subclassed.

To fix this, you need to mark the `NetworkClientManager` class as `open` instead of `public`. Here’s how you can modify the class definition:

```swift
open class NetworkClientManager<Target: RequestBuilder> {
    // The URLSession client is used to call request with URLSession Data Task Publisher
    private let clientURLSession: NetworkClient

    public init(clientURLSession: NetworkClient = DefaultNetworkClient()) {
        self.clientURLSession = clientURLSession
    }

    public func request<M: Decodable, T: Scheduler>(
        _ request: Target,
        decoder: JSONDecoder = JSONDecoder(),
        scheduler: T,
        responseObject type: M.Type
    ) -> AnyPublisherResult<M> {
        clientURLSession.perform(with: request,
                                 decoder: decoder,
                                 scheduler: scheduler,
                                 responseObject: type)
    }
}
```

Now, you can inherit from `NetworkClientManager` in your `DefaultMoviesDataProvider` class:

```swift
public class DefaultMoviesDataProvider: NetworkClientManager<DefaultHTTPRequest>, MoviesDataProvider {
    public func getTrendingList(_ target: TmdbApiTarget) -> AnyPublisherResult<MoviesResponse> {
        self.request(DefaultHTTPRequest(request: target),
                     scheduler: WorkScheduler.mainScheduler,
                     responseObject: MoviesResponse.self)
    }
}
```

This change will allow the `DefaultMoviesDataProvider` class to inherit from `NetworkClientManager` without any issues.